### PR TITLE
Cleanup the formatting scripts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -48,7 +48,6 @@ BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     100
 CommentPragmas:  '^ IWYU pragma:'
@@ -62,40 +61,17 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Preserve
-IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-    SortPriority:    0
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-    SortPriority:    0
-  - Regex:           '.*'
-    Priority:        1
-    SortPriority:    0
-IncludeIsMainRegex: '(Test)?$'
-IncludeIsMainSourceRegex: ''
 IndentCaseLabels: false
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces: true
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: 'MOPS_CATCH_EXCEPTIONS_BEGIN'
 MacroBlockEnd:   'MOPS_CATCH_EXCEPTIONS_END'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -104,9 +80,9 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 20
 PenaltyReturnTypeOnItsOwnLine: 1000000
-PointerAlignment: Right
+PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
@@ -128,9 +104,6 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 Standard:        Latest
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never

--- a/mops-torch/include/mops/torch/hpe.hpp
+++ b/mops-torch/include/mops/torch/hpe.hpp
@@ -16,11 +16,11 @@ class HomogeneousPolynomialEvaluation
     : public torch::autograd::Function<mops_torch::HomogeneousPolynomialEvaluation> {
   public:
     static torch::Tensor forward(
-        torch::autograd::AutogradContext *ctx, torch::Tensor A, torch::Tensor C, torch::Tensor indices_A
+        torch::autograd::AutogradContext* ctx, torch::Tensor A, torch::Tensor C, torch::Tensor indices_A
     );
 
     static std::vector<torch::Tensor> backward(
-        torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 

--- a/mops-torch/include/mops/torch/opsa.hpp
+++ b/mops-torch/include/mops/torch/opsa.hpp
@@ -25,7 +25,7 @@ torch::Tensor outer_product_scatter_add(
 class OuterProductScatterAdd : public torch::autograd::Function<mops_torch::OuterProductScatterAdd> {
   public:
     static torch::Tensor forward(
-        torch::autograd::AutogradContext *ctx,
+        torch::autograd::AutogradContext* ctx,
         torch::Tensor A,
         torch::Tensor B,
         torch::Tensor indices_output,
@@ -33,7 +33,7 @@ class OuterProductScatterAdd : public torch::autograd::Function<mops_torch::Oute
     );
 
     static std::vector<torch::Tensor> backward(
-        torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 

--- a/mops-torch/include/mops/torch/opsaw.hpp
+++ b/mops-torch/include/mops/torch/opsaw.hpp
@@ -16,7 +16,7 @@ class OuterProductScatterAddWithWeights
     : public torch::autograd::Function<mops_torch::OuterProductScatterAddWithWeights> {
   public:
     static torch::Tensor forward(
-        torch::autograd::AutogradContext *ctx,
+        torch::autograd::AutogradContext* ctx,
         torch::Tensor A,
         torch::Tensor B,
         torch::Tensor W,
@@ -25,7 +25,7 @@ class OuterProductScatterAddWithWeights
     );
 
     static std::vector<torch::Tensor> backward(
-        torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 

--- a/mops-torch/include/mops/torch/sap.hpp
+++ b/mops-torch/include/mops/torch/sap.hpp
@@ -22,7 +22,7 @@ class SparseAccumulationOfProducts
     : public torch::autograd::Function<mops_torch::SparseAccumulationOfProducts> {
   public:
     static torch::Tensor forward(
-        torch::autograd::AutogradContext *ctx,
+        torch::autograd::AutogradContext* ctx,
         torch::Tensor A,
         torch::Tensor B,
         torch::Tensor C,
@@ -33,7 +33,7 @@ class SparseAccumulationOfProducts
     );
 
     static std::vector<torch::Tensor> backward(
-        torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 

--- a/mops-torch/include/mops/torch/sasaw.hpp
+++ b/mops-torch/include/mops/torch/sasaw.hpp
@@ -25,7 +25,7 @@ class SparseAccumulationScatterAddWithWeights
     : public torch::autograd::Function<mops_torch::SparseAccumulationScatterAddWithWeights> {
   public:
     static torch::Tensor forward(
-        torch::autograd::AutogradContext *ctx,
+        torch::autograd::AutogradContext* ctx,
         torch::Tensor A,
         torch::Tensor B,
         torch::Tensor C,
@@ -39,7 +39,7 @@ class SparseAccumulationScatterAddWithWeights
     );
 
     static std::vector<torch::Tensor> backward(
-        torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+        torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
     );
 };
 

--- a/mops-torch/include/mops/torch/utils.hpp
+++ b/mops-torch/include/mops/torch/utils.hpp
@@ -30,11 +30,11 @@ template <typename T> static mops::Tensor<T, 3> torch_to_mops_3d(torch::Tensor t
     };
 }
 
-void check_all_same_device(const std::vector<torch::Tensor> &tensors);
+void check_all_same_device(const std::vector<torch::Tensor>& tensors);
 
-void check_floating_dtype(const std::vector<torch::Tensor> &tensors);
+void check_floating_dtype(const std::vector<torch::Tensor>& tensors);
 
-void check_integer_dtype(const std::vector<torch::Tensor> &tensors);
+void check_integer_dtype(const std::vector<torch::Tensor>& tensors);
 
 void check_all_same_dtype(std::vector<torch::Tensor> tensors);
 

--- a/mops-torch/src/hpe.cpp
+++ b/mops-torch/src/hpe.cpp
@@ -10,7 +10,7 @@ torch::Tensor mops_torch::homogeneous_polynomial_evaluation(
 }
 
 torch::Tensor HomogeneousPolynomialEvaluation::forward(
-    torch::autograd::AutogradContext *ctx, torch::Tensor A, torch::Tensor C, torch::Tensor indices_A
+    torch::autograd::AutogradContext* ctx, torch::Tensor A, torch::Tensor C, torch::Tensor indices_A
 ) {
     details::check_all_same_device({A, C, indices_A});
     details::check_floating_dtype({A, C});
@@ -53,7 +53,7 @@ torch::Tensor HomogeneousPolynomialEvaluation::forward(
 }
 
 std::vector<torch::Tensor> HomogeneousPolynomialEvaluation::backward(
-    torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+    torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
     auto A = saved_variables[0];

--- a/mops-torch/src/opsa.cpp
+++ b/mops-torch/src/opsa.cpp
@@ -10,7 +10,7 @@ torch::Tensor mops_torch::outer_product_scatter_add(
 }
 
 torch::Tensor OuterProductScatterAdd::forward(
-    torch::autograd::AutogradContext *ctx,
+    torch::autograd::AutogradContext* ctx,
     torch::Tensor A,
     torch::Tensor B,
     torch::Tensor indices_output,
@@ -77,7 +77,7 @@ torch::Tensor OuterProductScatterAdd::forward(
 }
 
 std::vector<torch::Tensor> OuterProductScatterAdd::backward(
-    torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+    torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
     auto A = saved_variables[0];

--- a/mops-torch/src/opsaw.cpp
+++ b/mops-torch/src/opsaw.cpp
@@ -10,7 +10,7 @@ torch::Tensor mops_torch::outer_product_scatter_add_with_weights(
 }
 
 torch::Tensor OuterProductScatterAddWithWeights::forward(
-    torch::autograd::AutogradContext *ctx,
+    torch::autograd::AutogradContext* ctx,
     torch::Tensor A,
     torch::Tensor B,
     torch::Tensor W,
@@ -67,7 +67,7 @@ torch::Tensor OuterProductScatterAddWithWeights::forward(
 }
 
 std::vector<torch::Tensor> OuterProductScatterAddWithWeights::backward(
-    torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+    torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
     auto A = saved_variables[0];

--- a/mops-torch/src/sap.cpp
+++ b/mops-torch/src/sap.cpp
@@ -18,7 +18,7 @@ torch::Tensor mops_torch::sparse_accumulation_of_products(
 }
 
 torch::Tensor SparseAccumulationOfProducts::forward(
-    torch::autograd::AutogradContext *ctx,
+    torch::autograd::AutogradContext* ctx,
     torch::Tensor A,
     torch::Tensor B,
     torch::Tensor C,
@@ -74,7 +74,7 @@ torch::Tensor SparseAccumulationOfProducts::forward(
 }
 
 std::vector<torch::Tensor> SparseAccumulationOfProducts::backward(
-    torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+    torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
     auto A = saved_variables[0];

--- a/mops-torch/src/sasaw.cpp
+++ b/mops-torch/src/sasaw.cpp
@@ -21,7 +21,7 @@ torch::Tensor mops_torch::sparse_accumulation_scatter_add_with_weights(
 }
 
 torch::Tensor SparseAccumulationScatterAddWithWeights::forward(
-    torch::autograd::AutogradContext *ctx,
+    torch::autograd::AutogradContext* ctx,
     torch::Tensor A,
     torch::Tensor B,
     torch::Tensor C,
@@ -106,7 +106,7 @@ torch::Tensor SparseAccumulationScatterAddWithWeights::forward(
 }
 
 std::vector<torch::Tensor> SparseAccumulationScatterAddWithWeights::backward(
-    torch::autograd::AutogradContext *ctx, std::vector<torch::Tensor> grad_outputs
+    torch::autograd::AutogradContext* ctx, std::vector<torch::Tensor> grad_outputs
 ) {
     auto saved_variables = ctx->get_saved_variables();
     auto A = saved_variables[0];

--- a/mops-torch/src/utils.cpp
+++ b/mops-torch/src/utils.cpp
@@ -4,12 +4,12 @@
 
 #include "mops/torch/utils.hpp"
 
-void mops_torch::details::check_all_same_device(const std::vector<torch::Tensor> &tensors) {
+void mops_torch::details::check_all_same_device(const std::vector<torch::Tensor>& tensors) {
     if (tensors.empty()) {
         return;
     }
     auto device = tensors[0].device();
-    for (const auto &tensor : tensors) {
+    for (const auto& tensor : tensors) {
         if (tensor.device() != device) {
             C10_THROW_ERROR(
                 ValueError,
@@ -20,7 +20,7 @@ void mops_torch::details::check_all_same_device(const std::vector<torch::Tensor>
     }
 }
 
-void mops_torch::details::check_floating_dtype(const std::vector<torch::Tensor> &tensors) {
+void mops_torch::details::check_floating_dtype(const std::vector<torch::Tensor>& tensors) {
     if (tensors.empty()) {
         return;
     }
@@ -31,7 +31,7 @@ void mops_torch::details::check_floating_dtype(const std::vector<torch::Tensor> 
             "Found dtype" + std::string(dtype.name()) + ", only float32 and float64 are supported"
         );
     }
-    for (const auto &tensor : tensors) {
+    for (const auto& tensor : tensors) {
         if (tensor.dtype() != dtype) {
             C10_THROW_ERROR(
                 TypeError,
@@ -42,8 +42,8 @@ void mops_torch::details::check_floating_dtype(const std::vector<torch::Tensor> 
     }
 }
 
-void mops_torch::details::check_integer_dtype(const std::vector<torch::Tensor> &tensors) {
-    for (const auto &tensor : tensors) {
+void mops_torch::details::check_integer_dtype(const std::vector<torch::Tensor>& tensors) {
+    for (const auto& tensor : tensors) {
         if (tensor.dtype() != torch::kI32) {
             C10_THROW_ERROR(
                 TypeError,

--- a/mops/benchmarks/utils.hpp
+++ b/mops/benchmarks/utils.hpp
@@ -1,6 +1,6 @@
 #include <random>
 
-void fill_vector_random_integers(std::vector<int32_t> &vector, size_t n) {
+void fill_vector_random_integers(std::vector<int32_t>& vector, size_t n) {
     // Random engine seeded with current time
     std::mt19937 engine(time(nullptr));
 
@@ -8,12 +8,12 @@ void fill_vector_random_integers(std::vector<int32_t> &vector, size_t n) {
     std::uniform_int_distribution<int32_t> distribution(0, n - 1);
 
     // Fill the vector with random numbers
-    for (auto &num : vector) {
+    for (auto& num : vector) {
         num = distribution(engine);
     }
 }
 
-template <typename scalar_t> void fill_vector_random_floats(std::vector<scalar_t> &vector) {
+template <typename scalar_t> void fill_vector_random_floats(std::vector<scalar_t>& vector) {
     // Random engine seeded with current time
     std::mt19937 engine(time(nullptr));
 
@@ -21,7 +21,7 @@ template <typename scalar_t> void fill_vector_random_floats(std::vector<scalar_t
     std::uniform_real_distribution<scalar_t> distribution(-1.0, 1.0);
 
     // Fill the vector with random numbers
-    for (auto &num : vector) {
+    for (auto& num : vector) {
         num = distribution(engine);
     }
 }

--- a/mops/examples/example.cu
+++ b/mops/examples/example.cu
@@ -33,10 +33,10 @@ int main() {
     auto indices_output = std::vector<int32_t>(100);
     auto output = std::vector<double>(10 * 20 * 5);
 
-    double *A_cuda;
-    double *B_cuda;
-    int32_t *indices_output_cuda;
-    double *output_cuda;
+    double* A_cuda;
+    double* B_cuda;
+    int32_t* indices_output_cuda;
+    double* output_cuda;
 
     CUDA_CHECK(cudaMalloc(&A_cuda, A.size() * sizeof(double)));
     CUDA_CHECK(cudaMalloc(&B_cuda, B.size() * sizeof(double)));

--- a/mops/include/mops.h
+++ b/mops/include/mops.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /// TODO
-MOPS_EXPORT const char *mops_get_last_error_message();
+MOPS_EXPORT const char* mops_get_last_error_message();
 
 #ifdef __cplusplus
 }

--- a/mops/include/mops/capi.hpp
+++ b/mops/include/mops/capi.hpp
@@ -7,7 +7,7 @@
 
 namespace mops {
 void store_error_message(std::string message);
-MOPS_EXPORT const std::string &get_last_error_message();
+MOPS_EXPORT const std::string& get_last_error_message();
 } // namespace mops
 
 #define MOPS_CATCH_EXCEPTIONS_BEGIN try {
@@ -15,7 +15,7 @@ MOPS_EXPORT const std::string &get_last_error_message();
 #define MOPS_CATCH_EXCEPTIONS_END                                                                  \
     return 0;                                                                                      \
     }                                                                                              \
-    catch (const std::exception &e) {                                                              \
+    catch (const std::exception& e) {                                                              \
         mops::store_error_message(e.what());                                                       \
         return 1;                                                                                  \
     }                                                                                              \

--- a/mops/include/mops/tensor.h
+++ b/mops/include/mops/tensor.h
@@ -9,42 +9,42 @@ extern "C" {
 #endif
 
 struct mops_tensor_3d_f32_t {
-    float *__restrict__ data;
+    float* __restrict__ data;
     int64_t shape[3];
 };
 
 struct mops_tensor_3d_f64_t {
-    double *__restrict__ data;
+    double* __restrict__ data;
     int64_t shape[3];
 };
 
 struct mops_tensor_2d_f32_t {
-    float *__restrict__ data;
+    float* __restrict__ data;
     int64_t shape[2];
 };
 
 struct mops_tensor_2d_f64_t {
-    double *__restrict__ data;
+    double* __restrict__ data;
     int64_t shape[2];
 };
 
 struct mops_tensor_1d_f32_t {
-    float *__restrict__ data;
+    float* __restrict__ data;
     int64_t shape[1];
 };
 
 struct mops_tensor_1d_f64_t {
-    double *__restrict__ data;
+    double* __restrict__ data;
     int64_t shape[1];
 };
 
 struct mops_tensor_1d_i32_t {
-    int32_t *__restrict__ data;
+    int32_t* __restrict__ data;
     int64_t shape[1];
 };
 
 struct mops_tensor_2d_i32_t {
-    int32_t *__restrict__ data;
+    int32_t* __restrict__ data;
     int64_t shape[2];
 };
 

--- a/mops/include/mops/tensor.hpp
+++ b/mops/include/mops/tensor.hpp
@@ -7,7 +7,7 @@ namespace mops {
 template <typename scalar_t, size_t N_DIMS> struct Tensor {
     /// Pointer to the first element of the tensor. The data must be
     /// contiguous and in row-major order.
-    scalar_t *__restrict__ data;
+    scalar_t* __restrict__ data;
     /// Shape of the tensor
     size_t shape[N_DIMS];
 };

--- a/mops/src/capi.cpp
+++ b/mops/src/capi.cpp
@@ -5,8 +5,8 @@ thread_local std::string LAST_ERROR_MESSAGE;
 
 void mops::store_error_message(std::string message) { LAST_ERROR_MESSAGE = std::move(message); }
 
-const std::string &mops::get_last_error_message() { return LAST_ERROR_MESSAGE; }
+const std::string& mops::get_last_error_message() { return LAST_ERROR_MESSAGE; }
 
-extern "C" const char *mops_get_last_error_message() {
+extern "C" const char* mops_get_last_error_message() {
     return mops::get_last_error_message().c_str();
 }

--- a/mops/src/internal/checks.hpp
+++ b/mops/src/internal/checks.hpp
@@ -21,12 +21,12 @@
 template <typename T_1, size_t N_DIMS_1, typename T_2, size_t N_DIMS_2>
 void check_sizes(
     mops::Tensor<T_1, N_DIMS_1> tensor_1,
-    const std::string &name_1,
+    const std::string& name_1,
     size_t dim_1,
     mops::Tensor<T_2, N_DIMS_2> tensor_2,
-    const std::string &name_2,
+    const std::string& name_2,
     size_t dim_2,
-    const std::string &operation
+    const std::string& operation
 ) {
     if (tensor_1.shape[dim_1] != tensor_2.shape[dim_2]) {
         throw std::runtime_error(
@@ -46,17 +46,17 @@ void check_sizes(
 template <size_t N_DIMS>
 void check_index_tensor(
     mops::Tensor<int32_t, N_DIMS> tensor,
-    const std::string &name,
+    const std::string& name,
     size_t max_value,
-    const std::string &operation
+    const std::string& operation
 ) {
-    int32_t *data_pointer = tensor.data;
+    int32_t* data_pointer = tensor.data;
     size_t total_size = 1;
     for (size_t i_dim = 0; i_dim < N_DIMS; i_dim++) {
         total_size *= tensor.shape[i_dim];
     }
-    int32_t *min_ptr = std::min_element(data_pointer, data_pointer + total_size);
-    int32_t *max_ptr = std::max_element(data_pointer, data_pointer + total_size);
+    int32_t* min_ptr = std::min_element(data_pointer, data_pointer + total_size);
+    int32_t* max_ptr = std::max_element(data_pointer, data_pointer + total_size);
     int32_t min = *min_ptr;
     int32_t max = *max_ptr;
     int32_t max_value_int32 = static_cast<int32_t>(max_value);
@@ -85,10 +85,10 @@ void check_index_tensor(
 template <typename T, size_t N_DIMS>
 void check_same_shape(
     mops::Tensor<T, N_DIMS> tensor_1,
-    const std::string &name_1,
+    const std::string& name_1,
     mops::Tensor<T, N_DIMS> tensor_2,
-    const std::string &name_2,
-    const std::string &operation
+    const std::string& name_2,
+    const std::string& operation
 ) {
     for (size_t i_dim = 0; i_dim < N_DIMS; i_dim++) {
         if (tensor_1.shape[i_dim] != tensor_2.shape[i_dim]) {

--- a/mops/src/internal/cuda_first_occurences.cu
+++ b/mops/src/internal/cuda_first_occurences.cu
@@ -12,15 +12,15 @@
 using namespace std;
 
 __global__ void calculate_first_occurences_kernel(
-    const int32_t *__restrict__ receiver_list,
+    const int32_t* __restrict__ receiver_list,
     const int32_t nelements,
-    const int32_t *__restrict__ sort_idx,
+    const int32_t* __restrict__ sort_idx,
     bool use_sort,
-    int32_t *__restrict__ first_occurences
+    int32_t* __restrict__ first_occurences
 ) {
     extern __shared__ char buffer[];
     size_t offset = 0;
-    int32_t *smem = reinterpret_cast<int32_t *>(buffer + offset);
+    int32_t* smem = reinterpret_cast<int32_t*>(buffer + offset);
 
     int32_t block_start = blockIdx.x * NELEMENTS_PER_BLOCK;
 
@@ -73,11 +73,11 @@ __global__ void calculate_first_occurences_kernel(
     }
 }
 
-int32_t *calculate_first_occurences_cuda(
-    const int32_t *receiver_list, int32_t nelements_input, int32_t nelements_output
+int32_t* calculate_first_occurences_cuda(
+    const int32_t* receiver_list, int32_t nelements_input, int32_t nelements_output
 ) {
 
-    static void *cached_first_occurences = nullptr;
+    static void* cached_first_occurences = nullptr;
     static size_t cached_size = 0;
 
     if (cached_size < nelements_output) {
@@ -86,7 +86,7 @@ int32_t *calculate_first_occurences_cuda(
         cached_size = nelements_output;
     }
 
-    int32_t *result = reinterpret_cast<int32_t *>(cached_first_occurences);
+    int32_t* result = reinterpret_cast<int32_t*>(cached_first_occurences);
 
     int32_t nbx = find_integer_divisor(nelements_input, NELEMENTS_PER_BLOCK);
 

--- a/mops/src/internal/cuda_first_occurences.cuh
+++ b/mops/src/internal/cuda_first_occurences.cuh
@@ -12,8 +12,8 @@
  *
  * This function allocates memory which must be freed with `cudaFree` when no longer required.
  */
-int32_t *calculate_first_occurences_cuda(
-    const int32_t *receiver_list, int32_t nelements_input, int32_t nelements_output
+int32_t* calculate_first_occurences_cuda(
+    const int32_t* receiver_list, int32_t nelements_input, int32_t nelements_output
 );
 
 #endif // MOPS_CUDA_FIRST_OCCURENCES_HPP

--- a/mops/src/internal/cuda_utils.cu
+++ b/mops/src/internal/cuda_utils.cu
@@ -12,25 +12,25 @@ __host__ __device__ int32_t find_integer_divisor(int32_t x, int32_t bdim) {
 }
 
 template <typename T>
-__host__ __device__ T *shared_array(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept {
+__host__ __device__ T* shared_array(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept {
     const std::uintptr_t inptr = reinterpret_cast<uintptr_t>(ptr);
     const std::uintptr_t end = inptr + n_elements * sizeof(T);
     if (space) {
         *space += static_cast<std::size_t>(end - inptr);
     }
-    ptr = reinterpret_cast<void *>(end);
-    return reinterpret_cast<T *>(inptr);
+    ptr = reinterpret_cast<void*>(end);
+    return reinterpret_cast<T*>(inptr);
 }
 
 // forward declare for different types...
-template float *shared_array<float>(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept;
-template double *shared_array<double>(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept;
-template int *shared_array<int>(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept;
-template short *shared_array<short>(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept;
+template float* shared_array<float>(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept;
+template double* shared_array<double>(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept;
+template int* shared_array<int>(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept;
+template short* shared_array<short>(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept;
 
 template <typename T>
-__host__ __device__ T *align_array(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+__host__ __device__ T* align_array(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept {
     const std::uintptr_t intptr = reinterpret_cast<uintptr_t>(ptr);
     const std::uintptr_t aligned = (intptr + alignment - 1) & -alignment;
@@ -38,20 +38,20 @@ __host__ __device__ T *align_array(
     if (space) {
         *space += static_cast<std::size_t>(end - intptr);
     }
-    ptr = reinterpret_cast<void *>(end);
-    return reinterpret_cast<T *>(aligned);
+    ptr = reinterpret_cast<void*>(end);
+    return reinterpret_cast<T*>(aligned);
 }
 
 // forward declare for different types...
-template float *align_array<float>(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+template float* align_array<float>(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept;
-template double *align_array<double>(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+template double* align_array<double>(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept;
-template int *align_array<int>(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+template int* align_array<int>(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept;
-template short *align_array<short>(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+template short* align_array<short>(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept;

--- a/mops/src/internal/cuda_utils.cuh
+++ b/mops/src/internal/cuda_utils.cuh
@@ -32,15 +32,15 @@ __host__ __device__ int32_t find_integer_divisor(int32_t x, int32_t bdim);
  *
  */
 template <class T>
-__host__ __device__ T *shared_array(std::size_t n_elements, void *&ptr, std::size_t *space) noexcept;
+__host__ __device__ T* shared_array(std::size_t n_elements, void*& ptr, std::size_t* space) noexcept;
 
 /*
  * helper function to allocate correctly sized shared memory buffers identically to the shared_array
  *  method, but in addition are aligned to a certain byte boundary given by alignment.
  */
 template <class T>
-__host__ __device__ T *align_array(
-    std::size_t n_elements, void *&ptr, const std::size_t alignment, std::size_t *space
+__host__ __device__ T* align_array(
+    std::size_t n_elements, void*& ptr, const std::size_t alignment, std::size_t* space
 ) noexcept;
 
 #endif // CUDA_UTILS_CUH

--- a/mops/src/internal/utils.cpp
+++ b/mops/src/internal/utils.cpp
@@ -6,7 +6,7 @@
 
 std::vector<std::vector<size_t>> get_write_list(mops::Tensor<int32_t, 1> write_coordinates) {
     std::vector<std::vector<size_t>> write_list(write_coordinates.shape[0]);
-    int32_t *write_coordinates_data = write_coordinates.data;
+    int32_t* write_coordinates_data = write_coordinates.data;
     for (size_t i = 0; i < write_coordinates.shape[0]; i++) {
         write_list[write_coordinates_data[i]].push_back(i);
     }

--- a/mops/src/internal/utils.hpp
+++ b/mops/src/internal/utils.hpp
@@ -33,14 +33,14 @@ template <> constexpr size_t get_simd_element_count<float>() {
 /// simd_element_count).
 template <typename scalar_t, size_t simd_element_count>
 void interleave_tensor(
-    mops::Tensor<scalar_t, 2> initial_data, scalar_t *interleft_data, scalar_t *remainder_data
+    mops::Tensor<scalar_t, 2> initial_data, scalar_t* interleft_data, scalar_t* remainder_data
 ) {
 
     size_t batch_dim = initial_data.shape[0];
     size_t remainder = batch_dim % simd_element_count;
     size_t quotient = batch_dim / simd_element_count;
     size_t calculation_dim = initial_data.shape[1];
-    scalar_t *initial_data_ptr = initial_data.data;
+    scalar_t* initial_data_ptr = initial_data.data;
 
 #pragma omp parallel for
     for (size_t i = 0; i < quotient; i++) {
@@ -65,14 +65,14 @@ void interleave_tensor(
 /// This is the inverse operation of interleave_tensor.
 template <typename scalar_t, size_t simd_element_count>
 void un_interleave_tensor(
-    mops::Tensor<scalar_t, 2> output_data, scalar_t *interleft_data, scalar_t *remainder_data
+    mops::Tensor<scalar_t, 2> output_data, scalar_t* interleft_data, scalar_t* remainder_data
 ) {
 
     size_t batch_dim = output_data.shape[0];
     size_t remainder = batch_dim % simd_element_count;
     size_t quotient = batch_dim / simd_element_count;
     size_t calculation_dim = output_data.shape[1];
-    scalar_t *output_data_ptr = output_data.data;
+    scalar_t* output_data_ptr = output_data.data;
 
 #pragma omp parallel for
     for (size_t i = 0; i < quotient; i++) {

--- a/mops/src/opsa/opsa.cpp
+++ b/mops/src/opsa/opsa.cpp
@@ -44,8 +44,14 @@ template void mops::cuda::outer_product_scatter_add<double>(
 );
 
 template <typename scalar_t>
-void mops::cuda::
-    outer_product_scatter_add_vjp(Tensor<scalar_t, 2>, Tensor<scalar_t, 2>, Tensor<scalar_t, 3>, Tensor<scalar_t, 2>, Tensor<scalar_t, 2>, Tensor<int32_t, 1>) {
+void mops::cuda::outer_product_scatter_add_vjp(
+    Tensor<scalar_t, 2> /*grad_A*/,
+    Tensor<scalar_t, 2> /*grad_B*/,
+    Tensor<scalar_t, 3> /*grad_output*/,
+    Tensor<scalar_t, 2> /*A*/,
+    Tensor<scalar_t, 2> /*B*/,
+    Tensor<int32_t, 1> /*indices_output*/
+) {
     throw std::runtime_error("MOPS was not compiled with CUDA support");
 }
 

--- a/mops/src/opsa/opsa.cu
+++ b/mops/src/opsa/opsa.cu
@@ -12,7 +12,7 @@ using namespace mops::cuda;
 #define FULL_MASK 0xffffffff
 
 template <typename scalar_t, const int32_t TA, const int32_t TB>
-__global__ __launch_bounds__(WARP_SIZE *NWARPS_PER_BLOCK) void outer_product_scatter_add_kernel(
+__global__ __launch_bounds__(WARP_SIZE* NWARPS_PER_BLOCK) void outer_product_scatter_add_kernel(
     Tensor<scalar_t, 2> A,
     Tensor<scalar_t, 2> B,
     Tensor<int32_t, 1> first_occurences,
@@ -133,7 +133,7 @@ void mops::cuda::outer_product_scatter_add(
     check_sizes(B, "B", 1, output, "output", 2, "opsa");
     check_sizes(A, "A", 0, indices_output, "indices_output", 0, "opsa");
 
-    int32_t *first_occurences =
+    int32_t* first_occurences =
         calculate_first_occurences_cuda(indices_output.data, A.shape[0], output.shape[0]);
 
     dim3 gridDim(output.shape[0], 1, 1);
@@ -159,7 +159,7 @@ template void mops::cuda::outer_product_scatter_add<double>(
 );
 
 template <typename scalar_t>
-__global__ void __launch_bounds__(NWARPS_PER_BLOCK *WARP_SIZE) outer_product_scatter_add_vjp_kernel(
+__global__ void __launch_bounds__(NWARPS_PER_BLOCK* WARP_SIZE) outer_product_scatter_add_vjp_kernel(
     Tensor<scalar_t, 2> A,
     Tensor<scalar_t, 2> B,
     Tensor<int32_t, 1> first_occurences,
@@ -175,16 +175,16 @@ __global__ void __launch_bounds__(NWARPS_PER_BLOCK *WARP_SIZE) outer_product_sca
     const int32_t threadRow = threadIdx.x / WARP_SIZE;
     const int32_t nThreadRow = blockDim.x / WARP_SIZE;
 
-    void *sptr = buffer;
+    void* sptr = buffer;
     size_t space = 0;
 
-    scalar_t *buffer_grad_in = shared_array<scalar_t>(A.shape[1] * B.shape[1], sptr, &space);
+    scalar_t* buffer_grad_in = shared_array<scalar_t>(A.shape[1] * B.shape[1], sptr, &space);
 
-    scalar_t *buffer_A = shared_array<scalar_t>(nThreadRow * A.shape[1], sptr, &space);
-    scalar_t *buffer_B = shared_array<scalar_t>(nThreadRow * B.shape[1], sptr, &space);
+    scalar_t* buffer_A = shared_array<scalar_t>(nThreadRow * A.shape[1], sptr, &space);
+    scalar_t* buffer_B = shared_array<scalar_t>(nThreadRow * B.shape[1], sptr, &space);
 
-    scalar_t *buffer_grad_A;
-    scalar_t *buffer_grad_B;
+    scalar_t* buffer_grad_A;
+    scalar_t* buffer_grad_B;
 
     if (grad_A.data != nullptr) {
         buffer_grad_A = shared_array<scalar_t>(nThreadRow * A.shape[1], sptr, &space);
@@ -308,14 +308,14 @@ void mops::cuda::outer_product_scatter_add_vjp(
     check_sizes(B, "B", 1, grad_output, "grad_output", 2, "cuda_opsa_vjp");
     check_sizes(A, "A", 0, indices_output, "indices_output", 0, "cuda_opsa_vjp");
 
-    int32_t *first_occurences =
+    int32_t* first_occurences =
         calculate_first_occurences_cuda(indices_output.data, A.shape[0], grad_output.shape[0]);
 
     dim3 gridDim(grad_output.shape[0], 1, 1);
 
     dim3 blockDim(NWARPS_PER_BLOCK * WARP_SIZE, 1, 1);
 
-    void *sptr = 0;
+    void* sptr = 0;
     size_t space = 0;
 
     shared_array<scalar_t>(A.shape[1] * B.shape[1], sptr, &space);

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,12 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-for file in $(find . -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cu" -o -name "*.cuh" \)  \
--not -path "*/external/*" -not -path "*/build/*" -not -path "*/.tox/*"); do
-    clang-format -i "$file"
-    if git diff --quiet "$file"; then
-    echo "✅ $file is properly formatted."
-    else
-    echo "❌ $file is not properly formatted. Please run './scripts/format.sh' from the mops root directory"
-    exit 1
-    fi
-done
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
+cd "$ROOT_DIR"
+
+find . -type f \(                            \
+        -name "*.c" -o -name "*.cpp"         \
+        -o -name "*.h" -o -name "*.hpp"      \
+        -o -name "*.cu" -o -name "*.cuh"     \
+    \)                                       \
+    -not -path "*/external/*"                \
+    -not -path "*/build/*"                   \
+    -not -path "*/.tox/*"                    \
+    -exec clang-format --dry-run --Werror {} \;

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-find . -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cu" -o -name "*.cuh" \)  \
--not -path "*/external/*" -not -path "*/build/*" -not -path "*/.tox/*" | xargs clang-format -i
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
+cd "$ROOT_DIR"
+
+find . -type f \(                            \
+        -name "*.c" -o -name "*.cpp"         \
+        -o -name "*.h" -o -name "*.hpp"      \
+        -o -name "*.cu" -o -name "*.cuh"     \
+    \)                                       \
+    -not -path "*/external/*"                \
+    -not -path "*/build/*"                   \
+    -not -path "*/.tox/*"                    \
+    -exec clang-format -i {} \;


### PR DESCRIPTION
Use `clang-format --dry-run --Werror` for checking and make sure the scripts can be used from anywhere.