### PR TITLE
Parallelize compilation with cmake

### DIFF
--- a/python/mops-torch/setup.py
+++ b/python/mops-torch/setup.py
@@ -37,6 +37,7 @@ class cmake_ext(build_ext):
                 "cmake",
                 "--build",
                 build_dir,
+                "--parallel",
                 "--config",
                 "Release",
                 "--target",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ class cmake_ext(build_ext):
                 "cmake",
                 "--build",
                 build_dir,
+                "--parallel",
                 "--config",
                 "Release",
                 "--target",

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ cmake-options =
 
 commands =
     cmake {toxinidir}/mops -B {envdir}/build {[testenv:cxx-tests]cmake-options}
-    cmake --build {envdir}/build --config Debug
+    cmake --build {envdir}/build --parallel --config Debug
     ctest --test-dir {envdir}/build --build-config Debug --output-on-failure
 
 
@@ -101,7 +101,7 @@ cmake-options =
 
 commands =
     cmake {toxinidir}/mops-torch -B {envdir}/build {[testenv:torch-cxx-tests]cmake-options}
-    cmake --build {envdir}/build --config Debug
+    cmake --build {envdir}/build --parallel --config Debug
 
 
 [testenv:build-python]


### PR DESCRIPTION
We use cmake's `--parallel` flag to speed up compilation for Python builds