### PR TITLE
Fix for edge-case issue with CUDA OPSA.

### DIFF
--- a/mops/src/internal/cuda_first_occurences.cu
+++ b/mops/src/internal/cuda_first_occurences.cu
@@ -24,6 +24,8 @@ __global__ void calculate_first_occurences_kernel(
 
     int32_t block_start = blockIdx.x * NELEMENTS_PER_BLOCK;
 
+    __syncthreads();
+
     // load all elements of senderlist needed by block into shared memory
     for (int32_t i = threadIdx.x; i < NELEMENTS_PER_BLOCK + 1; i += blockDim.x) {
         int32_t idx = block_start + i;
@@ -87,6 +89,9 @@ int32_t* calculate_first_occurences_cuda(
     }
 
     int32_t* result = reinterpret_cast<int32_t*>(cached_first_occurences);
+
+    // set to -1 as default so boundaries can be detected.
+    cudaMemset(result, -1, nelements_output * sizeof(int32_t));
 
     int32_t nbx = find_integer_divisor(nelements_input, NELEMENTS_PER_BLOCK);
 

--- a/mops/src/opsa/opsa.cu
+++ b/mops/src/opsa/opsa.cu
@@ -24,98 +24,44 @@ __global__ __launch_bounds__(WARP_SIZE* NWARPS_PER_BLOCK) void outer_product_sca
 
     const int32_t threadCol = threadIdx.x % WARP_SIZE;
     const int32_t threadRow = threadIdx.x / WARP_SIZE;
-    const int32_t nThreadRow = blockDim.x / WARP_SIZE;
+    const int32_t nThreadRow = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
 
-    /* registers to hold components of A, B and output - used to increase
-     * arithmetic intensity.
-     */
-    scalar_t regA[TA] = {0.0};
-    scalar_t regB[TB] = {0.0};
-    scalar_t regOP[TA * TB] = {0.0};
+    int32_t sample_start = first_occurences.data[blockIdx.x];
+    int32_t sample_end = -1;
+    int32_t node_index = -1;
 
-    const int32_t sample_start = first_occurences.data[blockIdx.x];
-    const int32_t sample_end =
-        (blockIdx.x == output.shape[0] - 1) ? A.shape[0] : first_occurences.data[blockIdx.x + 1];
-    const int32_t node_index = indices_output.data[sample_start];
-    const int32_t nsamples = sample_end - sample_start;
+    if (sample_start != -1) {
+        node_index = indices_output.data[sample_start];
+        sample_end = (blockIdx.x == first_occurences.shape[0] - 1)
+                         ? indices_output.shape[0]
+                         : (first_occurences.data[blockIdx.x + 1] == -1
+                                ? indices_output.shape[0]
+                                : first_occurences.data[blockIdx.x + 1]);
+    }
+
+    int32_t nsamples = sample_end - sample_start;
+
+    if (nsamples == 0) {
+        return;
+    }
 
     /* total number of columns of A we can process is TA * WARP_SIZE, so
      * we need to loop find_integer_divisor( A.shape[1], TA*WARP_SIZE) times
      */
 
-    int32_t niter_A = find_integer_divisor(A.shape[1], TA * nThreadRow);
-    int32_t niter_B = find_integer_divisor(B.shape[1], TB * WARP_SIZE);
+    for (int i = threadRow; i < A.shape[1]; i += nThreadRow) {
+        for (int j = threadCol; j < B.shape[1]; j += WARP_SIZE) {
 
-    for (int32_t iter_B = 0; iter_B < niter_B; iter_B++) {
-        int32_t global_B = iter_B * TB * WARP_SIZE;
-
-        for (int32_t iter_A = 0; iter_A < niter_A; iter_A++) {
-            int32_t global_A = iter_A * TA * nThreadRow;
-
-            /*
-             *  clear registers
-             */
-            for (int32_t i = 0; i < TA; i++) {
-                regA[i] = 0;
-            }
-
-            for (int32_t i = 0; i < TB; i++) {
-                regB[i] = 0;
-            }
-
-            for (int32_t i = 0; i < TA * TB; i++) {
-                regOP[i] = 0.0;
-            }
+            scalar_t reg_output = 0.0;
 
             for (int32_t sample_idx = 0; sample_idx < nsamples; sample_idx++) {
 
                 int32_t sample = sample_idx + sample_start;
 
-                /*
-                 *  load A from GMEM into local registers
-                 */
-                for (int32_t i = 0; i < TA; i++) {
-                    if (global_A + i * nThreadRow + threadRow < A.shape[1]) {
-                        regA[i] =
-                            A.data[sample * A.shape[1] + global_A + i * nThreadRow + threadRow];
-                    }
-                }
-
-                /*
-                 *  load B from GMEM into local registers
-                 */
-                for (int32_t i = 0; i < TB; i++) {
-                    if (global_B + i * WARP_SIZE + threadCol < B.shape[1]) {
-                        regB[i] = B.data[sample * B.shape[1] + global_B + i * WARP_SIZE + threadCol];
-                    }
-                }
-
-                /*
-                 * perform outer product in registers
-                 */
-                for (int32_t i = 0; i < TA; i++) {
-                    for (int32_t j = 0; j < TB; j++) {
-                        regOP[i * TB + j] += regA[i] * regB[j];
-                    }
-                }
+                reg_output += A.data[sample * A.shape[1] + i] * B.data[sample * B.shape[1] + j];
             }
 
-            /*
-             * writeout the content of regOP to the output for this block of
-             * [node,  A.shape[1], B.shape[1]]
-             */
-            for (int32_t j = 0; j < TB; j++) {
-                if (global_B + j * WARP_SIZE + threadCol < B.shape[1]) {
-                    for (int32_t i = 0; i < TA; i++) {
-                        if (global_A + i * nThreadRow + threadRow < A.shape[1]) {
-                            output.data
-                                [node_index * B.shape[1] * A.shape[1] +
-                                 (global_A + i * nThreadRow + threadRow) * B.shape[1] + global_B +
-                                 j * WARP_SIZE + threadCol] = regOP[i * TB + j];
-                        }
-                    }
-                }
-            }
+            output.data[node_index * A.shape[1] * B.shape[1] + i * B.shape[1] + j] = reg_output;
         }
     }
 }
@@ -133,15 +79,16 @@ void mops::cuda::outer_product_scatter_add(
     check_sizes(B, "B", 1, output, "output", 2, "opsa");
     check_sizes(A, "A", 0, indices_output, "indices_output", 0, "opsa");
 
-    int32_t* first_occurences =
-        calculate_first_occurences_cuda(indices_output.data, A.shape[0], output.shape[0]);
+    int32_t* first_occurences = calculate_first_occurences_cuda(
+        indices_output.data, indices_output.shape[0], output.shape[0]
+    );
 
     dim3 gridDim(output.shape[0], 1, 1);
 
-    dim3 blockDim(NWARPS_PER_BLOCK * WARP_SIZE, 1, 1);
+    dim3 blockDim(WARP_SIZE * NWARPS_PER_BLOCK, 1, 1);
 
     outer_product_scatter_add_kernel<scalar_t, 2, 2><<<gridDim, blockDim, 0>>>(
-        A, B, mops::Tensor<int32_t, 1>{first_occurences, {A.shape[0]}}, indices_output, output
+        A, B, mops::Tensor<int32_t, 1>{first_occurences, {output.shape[0]}}, indices_output, output
     );
 
     CUDA_CHECK_ERROR(cudaGetLastError());
@@ -308,8 +255,9 @@ void mops::cuda::outer_product_scatter_add_vjp(
     check_sizes(B, "B", 1, grad_output, "grad_output", 2, "cuda_opsa_vjp");
     check_sizes(A, "A", 0, indices_output, "indices_output", 0, "cuda_opsa_vjp");
 
-    int32_t* first_occurences =
-        calculate_first_occurences_cuda(indices_output.data, A.shape[0], grad_output.shape[0]);
+    int32_t* first_occurences = calculate_first_occurences_cuda(
+        indices_output.data, indices_output.shape[0], grad_output.shape[0]
+    );
 
     dim3 gridDim(grad_output.shape[0], 1, 1);
 
@@ -334,7 +282,7 @@ void mops::cuda::outer_product_scatter_add_vjp(
     outer_product_scatter_add_vjp_kernel<scalar_t><<<gridDim, blockDim, space>>>(
         A,
         B,
-        mops::Tensor<int32_t, 1>{first_occurences, {A.shape[0]}},
+        mops::Tensor<int32_t, 1>{first_occurences, {grad_output.shape[0]}},
         indices_output,
         grad_output,
         grad_A,


### PR DESCRIPTION
The code supported 0-neighbour nodes, **except** when the last node in a sample has 0 neighbours... the code was including all edges as to the summation.

Instead, I now fill the first_occurences list with -1's, and do some additional checks in the CUDA code to correctly differentiate 0-neighbour nodes vs nodes with neighbours.